### PR TITLE
updated to support newer Arduino core for ESP8266 WiFi chip

### DIFF
--- a/ESP_ThetaRemote.ino
+++ b/ESP_ThetaRemote.ino
@@ -380,6 +380,7 @@ int SearchAndEnterTHETA(void)
   int iRet = 0;
   int iThetaCnt=0;
   int aiSsidPosList[SEARCH_MAX_NUM];
+  char ssidbuf[256];
   
   Serial.println("");
   Serial.println("Search THETA");
@@ -402,7 +403,8 @@ int SearchAndEnterTHETA(void)
       Serial.println((WiFi.encryptionType(i) == ENC_TYPE_NONE)?" ":"*");
 
       if( WiFi.RSSI(i) >= NEAR_RSSI_THRESHOLD ) {
-        if ( CheckThetaSsid(WiFi.SSID(i)) == 1 ) {
+        WiFi.SSID(i).toCharArray(ssidbuf, sizeof(ssidbuf));
+        if ( CheckThetaSsid(ssidbuf) == 1 ) {
           if ( iThetaCnt < SEARCH_MAX_NUM ) {
             aiSsidPosList[iThetaCnt]=i;
             iThetaCnt++;
@@ -423,7 +425,8 @@ int SearchAndEnterTHETA(void)
         }
       }
       //Enter THETA SSID to EEPROM
-      SaveThetaSsid( (char*)WiFi.SSID(aiSsidPosList[iRssiMaxPos]) );
+      WiFi.SSID(aiSsidPosList[iRssiMaxPos]).toCharArray(ssidbuf, sizeof(ssidbuf));
+      SaveThetaSsid(ssidbuf);
       Serial.println("");
       Serial.println("--- Detected TEHTA ---");
       Serial.print("SSID=");


### PR DESCRIPTION
The return values of SSID() and psk() on “Arduino core for ESP8266”
library was changed from char \* into String on Oct 1.
( https://github.com/esp8266/Arduino/commit/0034697b6ef70eb5e38c4d576502f8deaa4c9438 ).
This modification is a quick fix to follow the library’s update.
